### PR TITLE
Modify translate/varcom.pm to add filtering on SCOWL scores

### DIFF
--- a/varcon/translate
+++ b/varcon/translate
@@ -13,6 +13,7 @@ $from = -1;
 @what = (\$from, \$to);
 $file = "varcon.txt";
 $ques = 0;
+$thresh = 100;
 
 while ($#ARGV != -1) {
     $p = shift @ARGV;
@@ -20,6 +21,10 @@ while ($#ARGV != -1) {
         $ques = 2;
     } elsif ($p eq "--include" || $p eq "-i") {
         $ques = 1;
+    } elsif ($p eq "--thresh" || $p eq "-t") {
+    	# Assign thresh
+    	$thresh = shift;
+    	&usage if ($thresh < 0 || $thresh > 100);
     } elsif ($p eq '-h' || $p eq '--help' || $p eq '-?') {
         print 
             "translate 1.1 by Kevin Atkinson\n",
@@ -28,6 +33,7 @@ while ($#ARGV != -1) {
             "  -?,-h,--help this screen\n",
             "  -m,--mark     mark words where the translation is questionable\n",
             "  -i,--include  include words where the translation is questionable\n",
+            "  -t,--thresh   threshold level (0-100), don't use variants with SCOWL > thresh\n",
             "<translation array> is the file name of the translation array,\n",
             "                    defaults to \"abbc.tab\".\n",
             "<from> and <to> are one of: american, british, or canadian\n";
@@ -56,7 +62,7 @@ while ($#ARGV != -1) {
         $$w = 'C';
     } else {
         $file = $p;
-    }
+    } 
 }
 
 &usage if ($to == -1 || $from == -1);
@@ -73,15 +79,23 @@ sub add(\@$) {
     push @{$_[0]}, $_[1];
 }
 
+my $level = 0;
+my $ret = 0;
 while (<IN>) {
-    next if varcon::filter $_;
-    my %r = varcon::readline($_);
-    foreach my $f ($from eq '-' ? (grep {$_ ne $to} keys %varcon::map) : $from) {
-        foreach my $v (0..3) {
-            foreach (@{$r{$f}[$v]}) {
-                add @{$trans{$_}}, $r{$to}[0][0];
-            }
-        }
+	$ret = varcon::filter($_);
+    if ($ret > 0) {
+    	$level = $ret;
+	}
+	else {
+		next if ($$level > $thresh);
+		my %r = varcon::readline($_);
+		foreach my $f ($from eq '-' ? (grep {$_ ne $to} keys %varcon::map) : $from) {
+		    foreach my $v (0..3) {
+		        foreach (@{$r{$f}[$v]}) {
+		            add @{$trans{$_}}, $r{$to}[0][0];
+		        }
+		    }
+		}
     }
 }
 

--- a/varcon/varcon.pm
+++ b/varcon/varcon.pm
@@ -158,9 +158,15 @@ sub get_words($) {
 }
 
 sub filter(\$;$) {
+	my $level;
     ${$_[0]} =~ s/^([^#\n]*)(.*)/$1/;
     ${$_[1]} = $2 if defined $_[1] && $2 ne '';
+    my $comment = $2;
+    if ( $comment =~ /\(level (\d+)\)/ ) {
+        $level = $1;
+    }
     ${$_[0]} =~ s/\s+$//;
-    return 1 if ${$_[0]} eq '';
+    
+    return \$level if ${$_[0]} eq '';
     return 0;
 }


### PR DESCRIPTION
I'm horrible at writing Perl code, but I hacked up a solution that adds a --thresh flag to ./translate (0-100). Please take a look and refactor it as needed.
