### PR TITLE
Fix en spelling suggestions for 'alot' and 'exersize'

### DIFF
--- a/scowl/speller/en.aff
+++ b/scowl/speller/en.aff
@@ -112,13 +112,14 @@ SFX B   e     able       [^aeiou]e
 SFX L Y 1
 SFX L   0     ment       .
 
-REP 88
+REP 90
 REP a ei
 REP ei a
 REP a ey
 REP ey a
 REP ai ie
 REP ie ai
+REP alot a_lot
 REP are air
 REP are ear
 REP are eir
@@ -201,3 +202,4 @@ REP ss z
 REP shun tion
 REP shun sion
 REP shun cion
+REP size cise


### PR DESCRIPTION
This is upstreamed from the changes made in Firefox.