### PR TITLE
Make en_CA point to the en_CA dictionary

### DIFF
--- a/site/dicts.md
+++ b/site/dicts.md
@@ -10,7 +10,7 @@ English are also available for Hunspell.
 * Official Hunspell Dictionaries: 
   [readme](/hunspell-readme),
   <a href="http://downloads.sourceforge.net/wordlist/hunspell-en_US-2015.05.18.zip">en_US</a>,
-  <a href="http://downloads.sourceforge.net/wordlist/hunspell-en_US-2015.05.18.zip">en_CA</a>
+  <a href="http://downloads.sourceforge.net/wordlist/hunspell-en_CA-2015.05.18.zip">en_CA</a>
   (2015.05.18) 
 * [Additional Hunspell Dictionaries](https://sourceforge.net/projects/wordlist/files/speller/2015.05.18)
   including ones for British English. 


### PR DESCRIPTION
Currently both the en_US link and the en_CA link point to the en_US dict. This PR fixes that.