### PR TITLE
en.aff: add REP to convert between ordinal number endings

### DIFF
--- a/scowl/speller/en.aff
+++ b/scowl/speller/en.aff
@@ -112,7 +112,7 @@ SFX B   e     able       [^aeiou]e
 SFX L Y 1
 SFX L   0     ment       .
 
-REP 90
+REP 93
 REP a ei
 REP ei a
 REP a ey
@@ -203,3 +203,6 @@ REP shun tion
 REP shun sion
 REP shun cion
 REP size cise
+REP th$ st
+REP th$ nd
+REP th$ rd


### PR DESCRIPTION
For "21th", hunspell suggested only "12th" instead of the more logical "21st". With this change it will suggest "21st" first.

I noticed that the lines I added were the only "anchored" REPs. I anchored them at the end of the word to avoid having th replaced in the middle of a word. Is that okay? Is there some technical reason to avoid those?

I considered adding REPs to convert between all four ordinal endings. I couldn't decide so I went with the minimal change.