### PR TITLE
Fix typos found by copdespell

### DIFF
--- a/agid/README
+++ b/agid/README
@@ -224,7 +224,7 @@ copyrights mentioned below.
   Copyright 2000-2014 by Kevin Atkinson
 
   Permission to use, copy, modify, distribute and sell this database,
-  the associated scripts, the output created form the scripts and its
+  the associated scripts, the output created from the scripts and its
   documentation for any purpose is hereby granted without fee,
   provided that the above copyright notice appears in all copies and
   that both that copyright notice and this permission notice appear in

--- a/agid/README
+++ b/agid/README
@@ -41,7 +41,7 @@ a few special verbs):
   <past tense> [<past participle>] <-ing form> <-s form> 
 and for adjective or adverbs:
   <-er form> <-est form>
-Each form is seperated by a ' | '.
+Each form is separated by a ' | '.
 
 Special cases:
 be:
@@ -79,15 +79,15 @@ current word.  A ? after a word means that the word was not in the
 word list but if it was it would be considered an inflected form of
 the base word.
 
-This verson is now almost as accurate as Alan Beale's 2of12id file
+This version is now almost as accurate as Alan Beale's 2of12id file
 distributed with the "Unofficial Alternate 12 Dicts Package" for the
 base words which have an entry in 2of12id.txt with a few notable
 exceptions.  The most obvious one is the "person" entry.  Alan Beale
 considers, based on what his sources have told him, that "persons" is
 the proper plural for "person" and "people" is considered a variant.
 I however disagree and decided to consider "people" the primary form
-and "persons" as the sligtly less perfered variant based on my own
-experence and http://www.quinion.com/words/usagenotes/un-person.htm
+and "persons" as the slightly less preferred variant based on my own
+experience and http://www.quinion.com/words/usagenotes/un-person.htm
 which says:
 
   The normal plural of person was persons ... However, there is

--- a/alt12dicts/README
+++ b/alt12dicts/README
@@ -56,7 +56,7 @@ entries will sum to the total dictionary count, while the scond-class
 entry count is independent of them, except that of course it is never
 greater than the total count.
 
-Words marked with a colon (":") after it are abbrevations which are
+Words marked with a colon (":") after it are abbreviations which are
 entirely lower-case and alphabetic.
 
 This file contains almost all the information found in the normal
@@ -153,7 +153,7 @@ Additional notes on the list from Alan:
   occasionally disagree.
 
 Variants.txt has not been updated for release 6, as critical
-information about how the list was contructed has unfortunately been
+information about how the list was constructed has unfortunately been
 lost.
 
 
@@ -191,7 +191,7 @@ See README-infl
 
 2of4brif.txt, 3esl.txt, and 5desk.txt neol2016.txt description:
 
-These files are identical to the orignal files in the 12Dicts package.
+These files are identical to the original files in the 12Dicts package.
 See README-orig for more info.
 
 

--- a/alt12dicts/README-infl
+++ b/alt12dicts/README-infl
@@ -91,7 +91,7 @@ mark the countability of plurals excluded via the hyphen notation.
 My notations for the precedence of multiple inflections for the same
 word are similar to the AGID notations but, because I do not feel I
 can in general accurately rank alternative forms by frequency of
-occurence, I use the notations somewhat differently.
+occurrence, I use the notations somewhat differently.
 
 When inflections are separated by a "/", it indicates that there is
 no clear agreement on which form appears first in the list of

--- a/scowl/r/README
+++ b/scowl/r/README
@@ -22,7 +22,7 @@ special:
   Special words lists that I added myself.
   Nothing needs to be downloaded for this directory.
 
-Plus the following additinal word list from various locations.
+Plus the following additional word list from various locations.
 
 census:
   1990 Census Name Files

--- a/scowl/r/special/README
+++ b/scowl/r/special/README
@@ -131,7 +131,7 @@ common.
 phrase-parts:
 
 Parts of common (generally Latin) phrases that are not normal words
-themselfs.
+themselves.
 
 australian.35:
 

--- a/scowl/speller/aspell-custom/README.in.sh
+++ b/scowl/speller/aspell-custom/README.in.sh
@@ -6,7 +6,7 @@ Original Word List By:
 Copyright Terms: Copyrighted (see the file Copyright for the exact terms)
 Wordlist URL: http://wordlist.aspell.net/
 
-Created with http://app.aspell.net/create with the following paramaters:
+Created with http://app.aspell.net/create with the following parameters:
 `cat "$PARMS_FILE"`
 
 This is a Custom English dictionary for Aspell.  It requires Aspell 
@@ -61,7 +61,7 @@ example to to make it the default for en_US:
 
 If you wish to use this dictionary with a particular program than does
 not allow you to directly select the dictionary than you can also add
-the alias to the ASPELL_CONF env. varable, for example:
+the alias to the ASPELL_CONF env. variable, for example:
   ASPELL_CONF='add-dict-alias en_US en-custom' emacs
 
 If you already have an English dictionary installed and do not wish to

--- a/site/12dicts-readme-r5.html
+++ b/site/12dicts-readme-r5.html
@@ -333,7 +333,7 @@ frequency are two forms of the verb "to be": "are" and "art".
 but&nbsp;it is credited with half the total count for the word, and
 thereby&nbsp;ends up in frequency band 5. &nbsp;(Not only are hardly
 any uses of "are"&nbsp;noun uses, but, almost certainly, most
-occurences of the plural "ares" are actually references to the Greek
+occurrences of the plural "ares" are actually references to the Greek
 god of war rather than to the unit.) &nbsp;"art" illustrates the other
 side of the problem. &nbsp;It is an archaic form of the verb "to be",
 and in this form is likely quite uncommon on the Web. &nbsp;The noun

--- a/site/_app/lookup-freq.cgi
+++ b/site/_app/lookup-freq.cgi
@@ -105,7 +105,7 @@ Newness score is defined as the frequency the word appears between the
 The "should incl" score indicates if a word should or should not be
 considered for inclusion in the given dictionary based on the
 frequency of the word in the corpus.  A word that is already included
-is labled as "incl.".  A word with 5 stars should most likely be
+is labeled as "incl.".  A word with 5 stars should most likely be
 included unless there is a good reason not to.  A word with 3 stars
 (***) is still worth considering and a word with 1 star (*) should
 most likely not be considered.

--- a/site/news.html
+++ b/site/news.html
@@ -183,7 +183,7 @@ dictionaries, created from SCOWL, is now available.
 
 <i>June 17, 2007</i><br>
 
-A new version of the offical 12Dicts package is now available which
+A new version of the official 12Dicts package is now available which
 contains several new lists.
 
 <p>
@@ -196,7 +196,7 @@ A new version of SCOWL, VarCon and, Alt12Dicts is now available.
 
 <i>January 27, 2003</i><br>
 
-A new version of the offical 12Dicts package is now available.
+A new version of the official 12Dicts package is now available.
 It differs from previous versions by containing three additional
 lists which are not derived from the "classic"  2dicts sources.
 Changes to the classic lists are limited to error corrections.
@@ -210,7 +210,7 @@ A new version of SCOWL, AGID, and VarCon is now available.
 
 <i>June 7, 2001</i><br>
 
-A new version of the offical 12Dicts package is now available.
+A new version of the official 12Dicts package is now available.
 It differs from previous versions primarily by replacement of one
 dictionary with another dictionary from the same
 publisher. Additionally, there have been many error corrections,
@@ -244,7 +244,7 @@ resulting from new editions of some of the source dictionaries.
 <p>
 
 <i>August 19,2000</i><br>
-A new revsion of SCOWL and AGID is now available.
+A new revision of SCOWL and AGID is now available.
 <p>
 The first version of "Unofficial Jargon File Word Lists" is now available
 <p>

--- a/site/other-dicts.md
+++ b/site/other-dicts.md
@@ -87,7 +87,7 @@ A version of David Bartlett list (based on R 1.20) with some minor changes by L�
 
 # Canadian (en_CA) #
 
-## Offical ##
+## Official ##
 
 * <http://wordlist.aspell.net/dicts>
 * Kevin Atkinson
@@ -121,7 +121,7 @@ A version with some minor changes by László Németh (Hunspell author) is inclu
 
 ## Others ##
 
-There was a version at www.JustLocal.com.au under a Free license.  However, the author pulled that version.  I belive there is a non-free one still available.
+There was a version at www.JustLocal.com.au under a Free license.  However, the author pulled that version.  I believe there is a non-free one still available.
 
 # New Zealand (en_NZ) #
 

--- a/varcon/README
+++ b/varcon/README
@@ -119,7 +119,7 @@ Varcon Groups
 -------------
 
 Sometimes the spelling of a word depends on the usage in which case a
-cluster is split into multiple groups, with each group represting one
+cluster is split into multiple groups, with each group representing one
 usage of a word.  Usage annotations and/or pos tags are used to
 distinguish one group from another.
 


### PR DESCRIPTION
Only under `site` and in `README`s.

I hope it is OK to modify [site/news.html](https://github.com/en-wl/wordlist/compare/master...DimitriPapadopoulos:site?expand=1#diff-24bf32bbf6ee2811adc1b1a036ec241b5fb2049e70065ac386d3b1efea771441).