### PR TITLE
Address "invalid escape sequence" warnings.

### DIFF
--- a/libscowl/__init__.py
+++ b/libscowl/__init__.py
@@ -66,7 +66,7 @@ def validateWord(w):
     if not m:
         raise ValueError(f"invalid word: {w}")
 
-wordPartRegex = re.compile(f'(\+?)({_wordRegex})([*@~!-]?)†?')
+wordPartRegex = re.compile(rf'(\+?)({_wordRegex})([*@~!-]?)†?')
 
 def parseWordPart(w):
     m = wordPartRegex.fullmatch(w)
@@ -653,7 +653,7 @@ class Line(LineBase):
             lemmaSpellingsKeys = '_',
         for w in wordStrs:
             w = w.strip()
-            m_ = re.fullmatch('\((.+)\)', w)
+            m_ = re.fullmatch(r'\((.+)\)', w)
             if m_:
                 wes = [we for we in (WordEntry.parse(w_.strip(), lemmaSpellingsKeys) for w_ in m_[1].split('|')) if we is not None]
             else:


### PR DESCRIPTION
Before this change:

    $ make -B scowl.db
    ./util/patch.py < patch > scowl-tmp.txt
    rm -f scowl.db
    ./scowl create-db scowl.db < scowl-tmp.txt
    .../wordlist/libscowl/__init__.py:69: SyntaxWarning: invalid escape sequence '\+'
      wordPartRegex = re.compile(f'(\+?)({_wordRegex})([*@~!-]?)†?')
    .../wordlist/libscowl/__init__.py:656: SyntaxWarning: invalid escape sequence '\('
      m_ = re.fullmatch('\((.+)\)', w)

Python warns us twice about using the "\\" character for an escape in a Python string, with an invalid following character.  In these two cases we want the "\\" escape character to exist literally in the string, to be consumed by the regular expression engine.

This is just what the "raw string" Python feature is for ( https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences -- keep literal backslashes in the string), adopted here.  Note that the (linked) documentation says "all unrecognized escape sequences are left in the string unchanged", so the existing code works with warnings, but also: "Changed in version 3.12: Unrecognized escape sequences produce a SyntaxWarning. In a future Python version they will be eventually a SyntaxError."  So while this is only a warning now, it will be more serious in the future.